### PR TITLE
Add basic API doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ docker-compose logs -f
 애플리케이션 실행 후 다음 URL에서 API 문서를 확인할 수 있습니다:
 - Swagger UI: http://localhost:8000/docs
 - ReDoc: http://localhost:8000/redoc
+- 추가적인 엔드포인트 설명은 [docs/API.md](docs/API.md) 파일을 참고하세요.
 
 ## 🔧 개발 환경
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,50 @@
+# API Overview
+
+This document summarizes the main API endpoints of the web hosting service.
+
+## Authentication
+
+### Register
+- **Endpoint**: `POST /api/v1/auth/register`
+- **Description**: Create a new user account.
+- **Body Example**:
+```json
+{
+  "email": "user@example.com",
+  "password": "password123",
+  "username": "myuser"
+}
+```
+
+### Login
+- **Endpoint**: `POST /api/v1/auth/login`
+- **Description**: Obtain a JWT token.
+- **Form Fields**: `username` (email) and `password`.
+
+## Hosting Management
+
+### Create Hosting
+- **Endpoint**: `POST /api/v1/hosting`
+- **Description**: Create a VM for the authenticated user.
+- **Auth**: Bearer token required.
+
+### Get My Hosting
+- **Endpoint**: `GET /api/v1/hosting/my`
+- **Description**: Retrieve the current user hosting details.
+- **Auth**: Bearer token required.
+
+### Delete My Hosting
+- **Endpoint**: `DELETE /api/v1/hosting/my`
+- **Description**: Remove the current user hosting and delete the VM.
+- **Auth**: Bearer token required.
+
+## Health Check
+
+### Basic Health Check
+- **Endpoint**: `GET /health`
+- **Description**: Returns `{"status": "healthy"}` if the service is running.
+
+### Detailed Health Check
+- **Endpoint**: `GET /health/detailed`
+- **Description**: Includes database status and environment information.
+


### PR DESCRIPTION
## Summary
- create `docs/API.md` with main endpoints
- link new doc in README

## Testing
- `pytest backend/tests/test_auth.py::TestAuthMe::test_get_current_user_invalid_token -q` *(fails: assert 500 == 401)*

------
https://chatgpt.com/codex/tasks/task_e_6846c38b6c48832ba49a9f7c6bad9d9e